### PR TITLE
Fix: Crash on fresh install of lunaryard (#51 fix)

### DIFF
--- a/src/terrain_management/terrain_manager.py
+++ b/src/terrain_management/terrain_manager.py
@@ -96,7 +96,8 @@ class TerrainManager:
         assert os.path.isdir(self._dems_path), "dems_path must be a directory."
 
         for folder in os.listdir(self._dems_path):
-            assert os.path.isdir(os.path.join(self._dems_path, folder)), "dems_path must contain only folders."
+            if not os.path.isdir(os.path.join(self._dems_path, folder)):
+                continue
             dem_path = os.path.join(self._dems_path, folder, "dem.npy")
             mask_path = os.path.join(self._dems_path, folder, "mask.npy")
             assert os.path.isfile(dem_path), "dem.npy not found in folder."


### PR DESCRIPTION
According to #51 , which has been closed because the problem was found but not solved.  
To avoid having to systematically remove the `.keepme` file to run the lunaryard, I propose a quick fix.

The issue was that for each node inside the lunaryard folder, it asserts whether it is actually a folder. But `.keepme` isn't one, so it triggered an assertion error.  
I propose turning this into a file-skipping behavior: any file inside this folder will simply be ignored.
act.